### PR TITLE
MLTD Compatibility

### DIFF
--- a/Apps/Hcaenc/DereTore.Apps.Hcaenc.csproj
+++ b/Apps/Hcaenc/DereTore.Apps.Hcaenc.csproj
@@ -54,14 +54,19 @@
     <LangVersion>6</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=2.2.1.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommandLineParser.2.2.1\lib\net40\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Apps/Hcaenc/Options.cs
+++ b/Apps/Hcaenc/Options.cs
@@ -1,0 +1,16 @@
+using CommandLine;
+
+namespace DereTore.Apps.Hcaenc {
+    public sealed class Options {
+
+        [Option('q', "quality", HelpText = "Audio quality (1 to 5)", Default = 1, Required = false)]
+        public int Quaility { get; set; } = 1;
+
+        [Value(0, HelpText = "Input file name", Required = true)]
+        public string InputFileName { get; set; }
+
+        [Value(1, HelpText = "Output HCA file name", Default = null, Required = false)]
+        public string OutputFileName { get; set; }
+
+    }
+}

--- a/Apps/Hcaenc/Program.cs
+++ b/Apps/Hcaenc/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace DereTore.Apps.Hcaenc {
@@ -9,19 +10,39 @@ namespace DereTore.Apps.Hcaenc {
                 Console.WriteLine(UnsupportedBuildMessage);
                 return -2;
             }
-            if (args.Length != 2) {
+
+            if (args.Length < 1) {
                 Console.WriteLine(HelpMessage);
                 return -1;
             }
-            int quality = 1, cutoff = 0;
+
+            var inputFile = args[0];
+
+            inputFile = Path.GetFullPath(inputFile);
+
+            string outputFile;
+
+            if (args.Length >= 2) {
+                outputFile = args[1];
+            } else {
+                var inputFileInfo = new FileInfo(inputFile);
+                var inputFileDir = inputFileInfo.DirectoryName;
+                outputFile = Path.Combine(inputFileDir, inputFileInfo.Name.Substring(0, inputFileInfo.Name.Length - inputFileInfo.Extension.Length) + ".hca");
+            }
+
+            Console.WriteLine("Encoding {0} to {1} ...", inputFile, outputFile);
+
+            // Quality = 3 (~128 Kbps) for MLTD, 1 (~256 Kbps) for CGSS
+            int quality = 3, cutoff = 0;
             ulong key = 0;
-            return hcaencEncodeToFile(args[0], args[1], quality, cutoff, key);
+
+            return hcaencEncodeToFile(inputFile, outputFile, quality, cutoff, key);
         }
 
         [DllImport("hcaenc_lite", CallingConvention = CallingConvention.StdCall)]
         private static extern int hcaencEncodeToFile([MarshalAs(UnmanagedType.LPStr)] string lpstrInputFile, [MarshalAs(UnmanagedType.LPStr)] string lpstrOutputFile, int nQuality, int nCutoff, ulong ullKey);
 
-        private static readonly string HelpMessage = "Usage: hcaenc.exe <input WAVE> <output HCA>";
+        private static readonly string HelpMessage = "Usage: hcaenc.exe <input WAVE> [<output HCA>]";
         private static readonly string UnsupportedBuildMessage = "hcaenc only has 32-bit version due to the limits of hcaenc_lite.dll.";
 
     }

--- a/Apps/Hcaenc/Program.cs
+++ b/Apps/Hcaenc/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using CommandLine;
 
 namespace DereTore.Apps.Hcaenc {
     internal static class Program {
@@ -11,29 +12,40 @@ namespace DereTore.Apps.Hcaenc {
                 return -2;
             }
 
-            if (args.Length < 1) {
+            var parser = new Parser(settings => { settings.IgnoreUnknownArguments = true; });
+
+            var parserResult = parser.ParseArguments<Options>(args);
+
+            if (parserResult.Tag == ParserResultType.NotParsed) {
                 Console.WriteLine(HelpMessage);
                 return -1;
             }
 
-            var inputFile = args[0];
+            var options = ((Parsed<Options>)parserResult).Value;
 
-            inputFile = Path.GetFullPath(inputFile);
+            var inputFile = Path.GetFullPath(options.InputFileName);
 
             string outputFile;
 
-            if (args.Length >= 2) {
-                outputFile = args[1];
+            if (!string.IsNullOrEmpty(options.OutputFileName)) {
+                outputFile = options.OutputFileName;
             } else {
                 var inputFileInfo = new FileInfo(inputFile);
                 var inputFileDir = inputFileInfo.DirectoryName;
                 outputFile = Path.Combine(inputFileDir, inputFileInfo.Name.Substring(0, inputFileInfo.Name.Length - inputFileInfo.Extension.Length) + ".hca");
             }
 
-            Console.WriteLine("Encoding {0} to {1} ...", inputFile, outputFile);
+            var quality = options.Quaility;
+
+            if (quality < 1 || quality > 5) {
+                Console.WriteLine("Warning: Quality should be 1 to 5. Using q=1.");
+                quality = 1;
+            }
+
+            Console.WriteLine("Encoding {0} to {1} (q={2}) ...", inputFile, outputFile, quality);
 
             // Quality = 3 (~128 Kbps) for MLTD, 1 (~256 Kbps) for CGSS
-            int quality = 3, cutoff = 0;
+            int cutoff = 0;
             ulong key = 0;
 
             return hcaencEncodeToFile(inputFile, outputFile, quality, cutoff, key);
@@ -42,7 +54,7 @@ namespace DereTore.Apps.Hcaenc {
         [DllImport("hcaenc_lite", CallingConvention = CallingConvention.StdCall)]
         private static extern int hcaencEncodeToFile([MarshalAs(UnmanagedType.LPStr)] string lpstrInputFile, [MarshalAs(UnmanagedType.LPStr)] string lpstrOutputFile, int nQuality, int nCutoff, ulong ullKey);
 
-        private static readonly string HelpMessage = "Usage: hcaenc.exe <input WAVE> [<output HCA>]";
+        private static readonly string HelpMessage = "Usage: hcaenc.exe <input WAVE> [<output HCA> -q <quality>]";
         private static readonly string UnsupportedBuildMessage = "hcaenc only has 32-bit version due to the limits of hcaenc_lite.dll.";
 
     }

--- a/Apps/Hcaenc/packages.config
+++ b/Apps/Hcaenc/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineParser" version="2.2.1" targetFramework="net40" />
+</packages>

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/AcbSerializer.Internal.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/AcbSerializer.Internal.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,57 +6,88 @@ using System.Linq;
 namespace DereTore.Exchange.Archive.ACB.Serialization {
     public partial class AcbSerializer {
 
-        private byte[] GetTableBytes<T>(T[] tableRows) where T : UtfRowBase {
+        /// <summary>
+        /// Get the unaligned byte array image of a table (UTF row).
+        /// Returned array should be aligned by <see cref="ArrayExtensions.RoundUpTo(byte[], int)"/>.
+        /// </summary>
+        /// <param name="tableRows">Rows in this table.</param>
+        /// <returns></returns>
+        private byte[] GetTableBytes(UtfRowBase[] tableRows) {
             var tableImage = PrepareTable(tableRows);
+
             byte[] buffer;
+
             using (var memory = new MemoryStream()) {
                 tableImage.WriteTo(memory);
-                //memory.Capacity = (int)AcbHelper.RoundUpToAlignment((int)memory.Length, Alignment);
-                buffer = new byte[memory.Length];
-                //memory.GetBuffer().CopyTo(buffer, 0);
-                Array.Copy(memory.GetBuffer(), buffer, buffer.Length);
+                buffer = memory.ToArray();
             }
+
             return buffer;
         }
 
-        private UtfTableImage PrepareTable<T>(T[] tableRows) where T : UtfRowBase {
-            var tableName = GetTableName(tableRows);
+        private UtfTableImage PrepareTable(UtfRowBase[] tableRows) {
+            if (tableRows.Length < 1) {
+                throw new ArgumentException("There should be at least one row in a table.", nameof(tableRows));
+            }
+
+            var tableRowTypes = tableRows.Select(row => row.GetType()).ToArray();
+
+            if (tableRowTypes.Length > 1) {
+                for (var i = 1; i < tableRowTypes.Length; ++i) {
+                    if (tableRowTypes[i] != tableRowTypes[i - 1]) {
+                        throw new ArgumentException("All rows must have the same CLR type.");
+                    }
+                }
+            }
+
+            var tableName = GetTableName(tableRows, tableRowTypes[0]);
             var tableImage = new UtfTableImage(tableName, Alignment);
+
             foreach (var tableRow in tableRows) {
                 var targetMembers = SerializationHelper.GetSearchTargetFieldsAndProperties(tableRow);
                 var tableImageRow = new List<UtfFieldImage>();
+
                 tableImage.Rows.Add(tableImageRow);
+
                 // TODO: Save misc data first, then the tables.
                 foreach (var member in targetMembers) {
                     var fieldInfo = member.FieldInfo;
                     var fieldType = fieldInfo.FieldType;
                     var fieldAttribute = member.FieldAttribute;
+
                     CheckFieldType(fieldType);
+
                     var fieldValue = member.FieldInfo.GetValue(tableRow);
+
                     var fieldImage = new UtfFieldImage {
                         Order = fieldAttribute.Order,
                         Name = string.IsNullOrEmpty(fieldAttribute.FieldName) ? fieldInfo.Name : fieldAttribute.FieldName,
                         Storage = fieldAttribute.Storage,
                     };
+
                     // Empty tables are treated as empty data.
                     if (IsTypeRowList(fieldType) && fieldValue != null && ((UtfRowBase[])fieldValue).Length > 0) {
                         var tableBytes = GetTableBytes((UtfRowBase[])fieldValue);
+
                         fieldImage.SetValue(tableBytes);
                         fieldImage.IsTable = true;
                     } else if (fieldType == typeof(byte[]) && member.ArchiveAttribute != null) {
                         var files = new List<byte[]> {
                             (byte[])fieldValue
                         };
+
                         var archiveBytes = SerializationHelper.GetAfs2ArchiveBytes(files.AsReadOnly(), Alignment);
+
                         fieldImage.SetValue(archiveBytes);
                         fieldImage.IsTable = true;
                     } else {
                         if (fieldValue == null) {
-                            fieldImage.SetNullValue(MapFromRawType(fieldType));
+                            fieldImage.SetNullValue(MapUtfColumeTypeFromRawType(fieldType));
                         } else {
                             fieldImage.SetValue(fieldValue);
                         }
                     }
+
                     tableImageRow.Add(fieldImage);
                 }
             }
@@ -73,31 +104,32 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
             return type.IsArray && type.HasElementType && type.GetElementType().IsSubclassOf(typeof(UtfRowBase));
         }
 
-        private static ColumnType MapFromRawType(Type rawType) {
+        private static ColumnType MapUtfColumeTypeFromRawType(Type rawType) {
             if (IsTypeRowList(rawType)) {
                 return ColumnType.Data;
             }
+
             var index = SupportedTypes.IndexOf(rawType);
+
             return (ColumnType)index;
         }
 
-        private static string GetTableName<T>(T[] tableRows) where T : UtfRowBase {
+        private static string GetTableName(UtfRowBase[] tableRows, Type tableType) {
             if (tableRows == null) {
                 throw new ArgumentNullException(nameof(tableRows));
             }
-            if (tableRows.Length < 1) {
-                throw new ArgumentException("There should be at least one row in a table.", nameof(tableRows));
-            }
-            // Assuming all the rows are of the same type.
-            var tableType = tableRows[0].GetType();
-            var tableAttributes = tableType.GetCustomAttributes(typeof(UtfTableAttribute), false);
-            if (tableAttributes.Length == 1) {
-                return ((UtfTableAttribute)tableAttributes[0]).Name;
+
+            var tableAttribute = SerializationHelper.GetCustomAttribute<UtfTableAttribute>(tableType);
+
+            if (!string.IsNullOrEmpty(tableAttribute?.Name)) {
+                return tableAttribute.Name;
             } else {
                 var s = tableType.Name;
+
                 if (s.EndsWith("Table")) {
                     s = s.Substring(0, s.Length - 5);
                 }
+
                 return s;
             }
         }

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/AcbSerializer.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/AcbSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using DereTore.Common;
 
@@ -9,22 +9,23 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
             Alignment = 32;
         }
 
-        public void Serialize<T>(T[] tableRows, Stream serializationStream) where T : UtfRowBase {
+        public void Serialize(UtfRowBase[] tableRows, Stream serializationStream) {
             if (tableRows == null) {
                 throw new ArgumentNullException(nameof(tableRows));
             }
+
             var tableData = GetTableBytes(tableRows).RoundUpTo(Alignment);
+
             serializationStream.WriteBytes(tableData);
         }
 
         public uint Alignment {
-            get {
-                return _alignment;
-            }
+            get { return _alignment; }
             set {
                 if (value <= 0 || value % 16 != 0) {
                     throw new ArgumentException("Alignment should be a positive integer, also a multiple of 16.", nameof(value));
                 }
+
                 _alignment = value;
             }
         }

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/ArrayExtensions.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/ArrayExtensions.cs
@@ -1,17 +1,21 @@
-﻿namespace DereTore.Exchange.Archive.ACB.Serialization {
+namespace DereTore.Exchange.Archive.ACB.Serialization {
     internal static class ArrayExtensions {
 
         public static byte[] RoundUpTo(this byte[] data, int alignment) {
             var newLength = AcbHelper.RoundUpToAlignment(data.Length, alignment);
             var buffer = new byte[newLength];
+
             data.CopyTo(buffer, 0);
+
             return buffer;
         }
 
         public static byte[] RoundUpTo(this byte[] data, uint alignment) {
             var newLength = AcbHelper.RoundUpToAlignment(data.Length, alignment);
             var buffer = new byte[newLength];
+
             data.CopyTo(buffer, 0);
+
             return buffer;
         }
 

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/SerializationHelper.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/SerializationHelper.cs
@@ -12,9 +12,9 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
             // This action seems weird. But it does exist (see Cue table in CGSS song_1001[oneshin]), I don't know why.
             value = AcbHelper.RoundUpToAlignment(value, 4);
 
-            //if (value % alignment == 0) {
-            //    value += alignment;
-            //}
+            if (value % alignment == 0) {
+                value += alignment;
+            }
 
             return AcbHelper.RoundUpToAlignment(value, alignment);
         }

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/SerializationHelper.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/SerializationHelper.cs
@@ -12,9 +12,9 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
             // This action seems weird. But it does exist (see Cue table in CGSS song_1001[oneshin]), I don't know why.
             value = AcbHelper.RoundUpToAlignment(value, 4);
 
-            if (value % alignment == 0) {
-                value += alignment;
-            }
+            //if (value % alignment == 0) {
+            //    value += alignment;
+            //}
 
             return AcbHelper.RoundUpToAlignment(value, alignment);
         }

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfFieldAttribute.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfFieldAttribute.cs
@@ -1,16 +1,16 @@
-﻿using System;
+using System;
 
 namespace DereTore.Exchange.Archive.ACB.Serialization {
     [AttributeUsage(AttributeTargets.Field)]
     public sealed class UtfFieldAttribute : Attribute {
 
-        public UtfFieldAttribute(int order, ColumnStorage storage = ColumnStorage.PerRow, string fieldName = null) {
+        public UtfFieldAttribute(int order = -1, ColumnStorage storage = ColumnStorage.PerRow, string fieldName = null) {
             Order = order;
             Storage = storage;
             FieldName = fieldName;
         }
 
-        public int Order { get; }
+        public int Order { get; internal set; }
 
         public string FieldName { get; }
 

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfFieldImage.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfFieldImage.cs
@@ -1,12 +1,9 @@
-﻿using System;
+using System;
 using System.IO;
 using DereTore.Common;
 
 namespace DereTore.Exchange.Archive.ACB.Serialization {
     internal sealed class UtfFieldImage : IComparable<UtfFieldImage> {
-
-        internal UtfFieldImage() {
-        }
 
         public ColumnStorage Storage { get; set; }
         public ColumnType Type { get; set; }
@@ -139,11 +136,11 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
         }
 
         public int CompareTo(UtfFieldImage other) {
-            return this.Order - other.Order;
+            return Order.CompareTo(other.Order);
         }
 
         public override string ToString() {
-            return $"UtfFieldImage {{{Name}}}";
+            return $"UtfFieldImage {{{Name}}} ({Type})";
         }
     }
 }

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfFieldImage.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfFieldImage.cs
@@ -26,6 +26,7 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
         public void SetValue(object value) {
             ColumnType type;
             var union = new NumericUnion();
+
             if (value is byte) {
                 type = ColumnType.Byte;
                 union.U8 = (byte)value;
@@ -65,7 +66,9 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
             } else {
                 throw new ArgumentException("Unsupported argument type.", nameof(value));
             }
+
             Type = type;
+
             switch (type) {
                 case ColumnType.String:
                 case ColumnType.Data:
@@ -128,7 +131,13 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
                     break;
                 case ColumnType.Data:
                     stream.WriteUInt32BE(DataOffset);
-                    stream.WriteUInt32BE((uint)DataValue.Length);
+
+                    // Tables ending locations, 4-byte alignment.
+                    if (IsTable) {
+                        stream.WriteUInt32BE(AcbHelper.RoundUpToAlignment((uint)DataValue.Length, 4));
+                    } else {
+                        stream.WriteUInt32BE((uint)DataValue.Length);
+                    }
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(Type));

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfRowBase.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfRowBase.cs
@@ -1,8 +1,5 @@
-﻿namespace DereTore.Exchange.Archive.ACB.Serialization {
+namespace DereTore.Exchange.Archive.ACB.Serialization {
     public abstract class UtfRowBase {
-
-        protected UtfRowBase() {
-        }
 
     }
 }

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfTableAttribute.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfTableAttribute.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 
 namespace DereTore.Exchange.Archive.ACB.Serialization {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public sealed class UtfTableAttribute : Attribute {
 
         public UtfTableAttribute(string name) {

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfTableImage.Output.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfTableImage.Output.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using DereTore.Common;
 
@@ -8,16 +8,20 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
         public void WriteTo(Stream bufferStream) {
             Rows.ForEach(row => {
                 row.Sort((t1, t2) => {
-                    if (!ReferenceEquals(t1, t2) && t1.Order == t2.Order) {
+                    if (!ReferenceEquals(t1, t2) && t1.Order.Equals(t2.Order)) {
                         throw new InvalidOperationException("Each field must have different order.");
                     }
-                    return t1.Order - t2.Order;
+
+                    return t1.Order.CompareTo(t2.Order);
                 });
             });
+
             ProcessStringTable();
             ProcessDataFields();
+
             UtfFieldImage[] orderedDataFieldImages;
             var header = GetHeader(out orderedDataFieldImages);
+
             WriteHeaderTo(header, bufferStream);
             SetStringFieldRelocations(header);
             SetExtraDataFieldRelocations(header, orderedDataFieldImages);
@@ -30,7 +34,7 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
         private static void WriteHeaderTo(UtfHeader header, Stream bufferStream) {
             bufferStream.SeekAndWriteBytes(UtfTable.UtfSignature, 0);
             bufferStream.SeekAndWriteUInt32BE(header.TableSize - 8, 4);
-            bufferStream.SeekAndWriteUInt16BE(1, 8);
+            bufferStream.SeekAndWriteUInt16BE(header.Unknown1, 8);
             bufferStream.SeekAndWriteUInt16BE((ushort)(header.PerRowDataOffset - 8), 10);
             bufferStream.SeekAndWriteUInt32BE(header.StringTableOffset - 8, 12);
             bufferStream.SeekAndWriteUInt32BE(header.ExtraDataOffset - 8, 16);
@@ -42,10 +46,13 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
 
         private void WriteFieldDescriptorsTo(UtfHeader header, Stream bufferStream) {
             bufferStream.Seek(SchemaOffset, SeekOrigin.Begin);
+
             var row = Rows[0];
+
             foreach (var fieldImage in row) {
                 bufferStream.WriteByte((byte)((byte)fieldImage.Storage | (byte)fieldImage.Type));
                 bufferStream.WriteUInt32BE(fieldImage.NameOffset);
+
                 if (fieldImage.Storage == ColumnStorage.Constant || fieldImage.Storage == ColumnStorage.Constant2) {
                     fieldImage.WriteValueTo(bufferStream);
                 }
@@ -54,6 +61,7 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
 
         private void WritePerRowDataTo(UtfHeader header, Stream bufferStream) {
             bufferStream.Seek(header.PerRowDataOffset, SeekOrigin.Begin);
+
             foreach (var row in Rows) {
                 foreach (var fieldImage in row) {
                     if (fieldImage.Storage == ColumnStorage.PerRow) {
@@ -66,15 +74,19 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
         private void WriteStringTableTo(UtfHeader header, Stream bufferStream) {
             bufferStream.Seek(header.StringTableOffset, SeekOrigin.Begin);
             bufferStream.WriteBytes(TableNameBytesCache);
+
             var row0 = Rows[0];
+
             foreach (var fieldImage in row0) {
                 bufferStream.WriteBytes(fieldImage.NameBytesCache);
             }
+
             foreach (var fieldImage in row0) {
                 if ((fieldImage.Storage == ColumnStorage.Constant || fieldImage.Storage == ColumnStorage.Constant2) && fieldImage.Type == ColumnType.String) {
                     bufferStream.WriteBytes(fieldImage.StringValueBytesCache);
                 }
             }
+
             foreach (var row in Rows) {
                 foreach (var fieldImage in row) {
                     if (fieldImage.Type == ColumnType.String && fieldImage.Storage == ColumnStorage.PerRow) {
@@ -86,11 +98,14 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
 
         private void WriteExtraDataTo(UtfHeader header, Stream bufferStream) {
             var baseOffset = header.ExtraDataOffset;
+
             for (var i = 0; i < Rows.Count; ++i) {
                 var row = Rows[i];
+
                 foreach (var fieldImage in row) {
                     if (fieldImage.Type == ColumnType.Data) {
                         var shouldWrite = false;
+
                         switch (fieldImage.Storage) {
                             case ColumnStorage.Constant:
                             case ColumnStorage.Constant2:
@@ -99,9 +114,8 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
                             case ColumnStorage.PerRow:
                                 shouldWrite = true;
                                 break;
-                            default:
-                                break;
                         }
+
                         if (shouldWrite && fieldImage.DataValue.Length > 0) {
                             bufferStream.SeekAndWriteBytes(fieldImage.DataValue, baseOffset + fieldImage.DataOffset);
                         }

--- a/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfTableImage.Preprocessor.cs
+++ b/Exchange/DereTore.Exchange.Archive.ACB/Serialization/UtfTableImage.Preprocessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using DereTore.Common;
 
@@ -14,7 +14,9 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
             if (Rows.Count < 1) {
                 throw new InvalidOperationException("Rows should not be empty.");
             }
+
             var fieldCount = Rows[0].Count;
+
             for (var i = 1; i < Rows.Count; ++i) {
                 if (Rows[i].Count != fieldCount) {
                     throw new InvalidOperationException("Number of fields in each row do not match.");
@@ -29,12 +31,16 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
                 RowSize = GetSingleRowDataSize(),
                 PerRowDataOffset = GetRowDescriptorSize() + SchemaOffset // "per row" data offset, actually
             };
+
             var perRowDataSize = header.RowCount * header.RowSize;
+
             header.StringTableOffset = header.PerRowDataOffset + perRowDataSize;
             header.TableNameOffset = 0;
 
             var stringTableSize = GetStringTableSize();
+
             header.ExtraDataOffset = header.StringTableOffset + stringTableSize;
+
             var extraDataSize = GetExtraDataSize(header, out orderedDataFieldImages);
 
             header.TableSize = header.ExtraDataOffset + extraDataSize;
@@ -44,10 +50,13 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
 
         private void ProcessStringTable() {
             TableNameBytesCache = Encoding.ASCII.GetBytes(TableName).Append(0);
+
             // Prepare static strings first.
             var row = Rows[0];
+
             foreach (var fieldImage in row) {
                 fieldImage.NameBytesCache = Encoding.ASCII.GetBytes(fieldImage.Name).Append(0);
+
                 switch (fieldImage.Storage) {
                     case ColumnStorage.Constant:
                     case ColumnStorage.Constant2:
@@ -59,16 +68,18 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
                             }
                         }
                         break;
-                    default:
-                        break;
                 }
             }
+
             var row0 = row;
+
             for (var i = 1; i < Rows.Count; ++i) {
                 for (var j = 0; j < Rows[i].Count; ++j) {
                     var fieldImage = Rows[i][j];
+
                     fieldImage.Name = row0[j].Name;
                     fieldImage.NameBytesCache = row0[j].NameBytesCache;
+
                     switch (fieldImage.Storage) {
                         case ColumnStorage.Constant:
                         case ColumnStorage.Constant2:
@@ -77,11 +88,10 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
                                 fieldImage.StringValueBytesCache = row0[j].StringValueBytesCache;
                             }
                             break;
-                        default:
-                            break;
                     }
                 }
             }
+
             // Per-row strings.
             foreach (var r in Rows) {
                 foreach (var fieldImage in r) {
@@ -111,11 +121,13 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
             var currentStringTableOffset = (uint)TableNameBytesCache.Length;
             var row0 = Rows[0];
             var row = row0;
+
             // Field names and static strings
             foreach (var fieldImage in row) {
                 fieldImage.NameOffset = currentStringTableOffset;
                 currentStringTableOffset += (uint)fieldImage.NameBytesCache.Length;
             }
+
             foreach (var fieldImage in row) {
                 switch (fieldImage.Storage) {
                     case ColumnStorage.Constant:
@@ -125,14 +137,15 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
                             currentStringTableOffset += (uint)fieldImage.StringValueBytesCache.Length;
                         }
                         break;
-                    default:
-                        break;
                 }
             }
+
             for (var i = 1; i < Rows.Count; ++i) {
                 for (var j = 0; j < Rows[i].Count; ++j) {
                     var fieldImage = Rows[i][j];
+
                     fieldImage.NameOffset = row0[j].NameOffset;
+
                     switch (fieldImage.Storage) {
                         case ColumnStorage.Constant:
                         case ColumnStorage.Constant2:
@@ -140,11 +153,10 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
                                 fieldImage.StringOffset = row0[j].StringOffset;
                             }
                             break;
-                        default:
-                            break;
                     }
                 }
             }
+
             // Per-row strings
             foreach (var r in Rows) {
                 foreach (var fieldImage in r) {
@@ -167,16 +179,20 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
                     if (fieldImage.IsTable) {
                         currentOffset = SerializationHelper.RoundUpAsTable(currentOffset, Alignment);
                     }
+
                     fieldImage.DataOffset = currentOffset - baseOffset;
                     currentOffset += (uint)fieldImage.DataValue.Length;
                 } else {
                     fieldImage.DataOffset = 0;
                 }
             }
+
             var row0 = Rows[0];
+
             for (var i = 1; i < Rows.Count; ++i) {
                 for (var j = 0; j < Rows[i].Count; ++j) {
                     var fieldImage = Rows[i][j];
+
                     if (fieldImage.Type == ColumnType.Data && (fieldImage.Storage == ColumnStorage.Constant || fieldImage.Storage == ColumnStorage.Constant2)) {
                         fieldImage.DataOffset = row0[j].DataOffset;
                     }
@@ -186,7 +202,7 @@ namespace DereTore.Exchange.Archive.ACB.Serialization {
 
         private static readonly byte[] EmptyByteArray = new byte[0];
         private static readonly byte[] EmptyAsciiStringBytes = new byte[1];
-        private static readonly ushort SchemaOffset = 0x20;
+        private const ushort SchemaOffset = 0x20;
 
     }
 }


### PR DESCRIPTION
MLTD uses different HCA quality setting and enforces strict ACB (v1.29.00) structure. For comparison, CGSS uses ACB (v1.23.00) which doesn't validate some miscalculations, especially aligntments.
This PR added the quality option, and fixes ACB calculations to enable MLTD-compatible ACB generation.