### PR TITLE
Fix LZ4 error and Remove Toolchain reliance over hcaenc_lite.dll

### DIFF
--- a/Apps/LZ4/Program.cs
+++ b/Apps/LZ4/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using DereTore.Common;
 using DereTore.Compression.LZ4;
@@ -7,9 +7,9 @@ namespace DereTore.Apps.LZ4 {
     internal static class Program {
 
         private static int Main(string[] args) {
-            if (args.Length < 1 && args.Length > 2) {
+            if (args.Length < 1 || args.Length > 2) {
                 Console.WriteLine(HelpMessage);
-                return 0;
+                return -1;
             }
             var inputFileName = args[0];
             string outputFileName;

--- a/Apps/MusicToolchain/FMain.cs
+++ b/Apps/MusicToolchain/FMain.cs
@@ -247,7 +247,7 @@ namespace DereTore.Apps.MusicToolchain {
             _logDelegate = Log;
             _enableControlsDelegate = EnableControls;
             _disableControlsDelegate = DisableControls;
-            var criticalFiles = new[] { "hcaenc.exe", "hcacc.exe", "AcbMaker.exe", "LZ4.exe", "hcaenc_lite.dll" };
+            var criticalFiles = new[] { "hcaenc.exe", "hcacc.exe", "AcbMaker.exe", "LZ4.exe" };
             var missingFiles = criticalFiles.Where(s => !File.Exists(s)).ToList();
             if (missingFiles.Count > 0) {
                 DisableControls();

--- a/Apps/MusicToolchain/README.md
+++ b/Apps/MusicToolchain/README.md
@@ -4,9 +4,7 @@ This project is meant for integrating the 3 tools: **AcbMaker**, **CipherConvert
 It provides an automatic streamline to create CGSS-compatible live music ACB files.
 
 In order to run the application, the executables of those tools must be placed under the directory
-containing the executable of this project. Additionally, the `hcaenc_lite.dll` must also be placed
-there, as it is a prerequisite for **Encoder**. Go to the [download page](http://adx2le.com/download/index.html)
-for it. Remember, it is only for domestic use in Japan, but it is not so difficult to get a copy.
+containing the executable of this project.
 
 ## How to use the utility
 


### PR DESCRIPTION
This pull request will fix these problems on the latest commit:

* LZ4 will crash right away when no argument or too many arguements provided.
> To fix this, I made the *always-false* code, `(args.Length < 1 && args.Length > 2)` to `(args.Length < 1 || args.Length > 2)`. Also, it now successfully returns code -1.

* Toolchain will not work without `hcaenc_lite.dll`, but Encoder and CipherConverter doesn't rely on it anymore.
> I just removed `hcaenc_lite.dll` from its `criticalFiles[]` variable.

Every changes here has tested locally. Environment:
```raw
Build:
* OS: Windows 11 Home, GL ko-KR
* CPU: Intel(R) CORE(TM) i5-9400
* RAM: DDR4 12GB
```
```raw
Test:
* OS: Windows 11 Home, GL ko-KR
* CPU: Intel(R) CORE(TM) 11th Gen i5-1135G7
* RAM: LPDDR4 8GB
* Additional Info: This environment is labtop.
```